### PR TITLE
Add support for keepInFrame tag.

### DIFF
--- a/examples/ex_keepinframe.pdf
+++ b/examples/ex_keepinframe.pdf
@@ -1,0 +1,49 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<< /F1 2 0 R >>
+endobj
+2 0 obj
+<< /BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font >>
+endobj
+3 0 obj
+<< /Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources << /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >> /Rotate 0 /Trans <<  >> 
+  /Type /Page >>
+endobj
+4 0 obj
+<< /Outlines 8 0 R /PageMode /UseNone /Pages 6 0 R /Type /Catalog >>
+endobj
+5 0 obj
+<< /Author (\(anonymous\)) /CreationDate (D:20160906192854-03'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20160906192854-03'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False >>
+endobj
+6 0 obj
+<< /Count 1 /Kids [ 3 0 R ] /Type /Pages >>
+endobj
+7 0 obj
+<< /Filter [ /ASCII85Decode /FlateDecode ] /Length 149 >>
+stream
+Gas3+0b/gi$jG#6P4.m9!8)92k"9`)60&4U2Cc-/+.=C.Ar48"#OCU^L(_%C4+TmkrtL85*t[`HH,c):?3h#_XZR%an_(0&]p[qf0L^l6&Z4[P0mS\(\USK\[Wi3]n_ccmRsN%2C<aTe"^*rA+9~>endstream
+endobj
+8 0 obj
+<< /Count 0 /Type /Outlines >>
+endobj
+xref
+0 9
+0000000000 65535 f
+0000000075 00000 n
+0000000109 00000 n
+0000000219 00000 n
+0000000416 00000 n
+0000000503 00000 n
+0000000790 00000 n
+0000000852 00000 n
+0000001096 00000 n
+trailer
+<< /ID 
+ % ReportLab generated PDF document -- digest (http://www.reportlab.com)
+ [(\016\031wW\3339\022n\264\235\264\356+\247\246\234) (\016\031wW\3339\022n\264\235\264\356+\247\246\234)]
+ /Info 5 0 R /Root 4 0 R /Size 9 >>
+startxref
+1145
+%%EOF

--- a/examples/ex_keepinframe.pdf
+++ b/examples/ex_keepinframe.pdf
@@ -1,4 +1,4 @@
-%PDF-1.3
+%PDF-1.4
 %“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
 1 0 obj
 << /F1 2 0 R >>
@@ -14,16 +14,16 @@ endobj
 << /Outlines 8 0 R /PageMode /UseNone /Pages 6 0 R /Type /Catalog >>
 endobj
 5 0 obj
-<< /Author (\(anonymous\)) /CreationDate (D:20160906192854-03'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20160906192854-03'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+<< /Author (\(anonymous\)) /CreationDate (D:20160906195638-03'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20160906195638-03'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
   /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False >>
 endobj
 6 0 obj
 << /Count 1 /Kids [ 3 0 R ] /Type /Pages >>
 endobj
 7 0 obj
-<< /Filter [ /ASCII85Decode /FlateDecode ] /Length 149 >>
+<< /Filter [ /ASCII85Decode /FlateDecode ] /Length 465 >>
 stream
-Gas3+0b/gi$jG#6P4.m9!8)92k"9`)60&4U2Cc-/+.=C.Ar48"#OCU^L(_%C4+TmkrtL85*t[`HH,c):?3h#_XZR%an_(0&]p[qf0L^l6&Z4[P0mS\(\USK\[Wi3]n_ccmRsN%2C<aTe"^*rA+9~>endstream
+Gb!;^9i$Er&A=:s+(fGlM:aHgHgkL=-PNhK`:LQE"GJb"Y&!t.[KqR<X*>@M1X&AP]f1QEfb_-\[Ka7ei:7Wc-BR>>=i;GpK:=D#,Z"t5A_+sG+eT!$KY^k06nH1Jhd+TsMu[4e+r"6k>IR2V\%+a9EfUa)2Pct__"Ji?Oqb45`Bo^)@_5hibH**20]Ku8;lG,PK-tXCfaD?RY\XZ[Q`lKd<C9]6$<ub)7R:?!.&Adp+`,T(p6CZq])P65O,9r")<-<FAKV;R,l-#bZX#^@;2Q4j=U=^sKGYBeKj[$6#Vi>f.A%bR4?:iQ,ON2sQ+VS_3j7&l8n\`@.m4&^\ml84E\meF>pABRK[eF:0(=)qo(X[QcV;D+SXbWRJ%IGQ3(uQ:`SqCp4(Mh.,UU9?9[TBKn]V&[S;4DM#-gV1.HRd37r,Jo4)_0;<eFn#5ilms]W5>E'D*FV^&Wbr"9S~>endstream
 endobj
 8 0 obj
 << /Count 0 /Type /Outlines >>
@@ -38,12 +38,12 @@ xref
 0000000503 00000 n
 0000000790 00000 n
 0000000852 00000 n
-0000001096 00000 n
+0000001412 00000 n
 trailer
 << /ID 
  % ReportLab generated PDF document -- digest (http://www.reportlab.com)
- [(\016\031wW\3339\022n\264\235\264\356+\247\246\234) (\016\031wW\3339\022n\264\235\264\356+\247\246\234)]
+ [(;\017R\243\244\355\007\354\222\327\025\033\3315\205\320) (;\017R\243\244\355\007\354\222\327\025\033\3315\205\320)]
  /Info 5 0 R /Root 4 0 R /Size 9 >>
 startxref
-1145
+1461
 %%EOF

--- a/examples/ex_keepinframe.rml
+++ b/examples/ex_keepinframe.rml
@@ -1,0 +1,45 @@
+<!DOCTYPE document SYSTEM "rml.dtd">
+<document>
+    <template pageSize="(8.5in, 11in)" showBoundary="1">
+        <pageTemplate id="main">
+            <frame id="testframe1" x1="0.5in" y1="9.5in" width="2in" height="1in"/>
+            <frame id="testframe2" x1="0.5in" y1="8in" width="2in" height="1in"/>
+            <frame id="testframe3" x1="0.5in" y1="6.5in" width="2in" height="1in"/>
+            <frame id="testframe4" x1="0.5in" y1="5in" width="2in" height="1in"/>
+            <frame id="testframe5" x1="0.5in" y1="3.5in" width="2in" height="1in"/>
+        </pageTemplate>
+    </template>
+    <stylesheet>
+    </stylesheet>
+    <story>
+        <keepInFrame onOverflow="shrink">
+            <para fontSize="30">
+                This text should be shrunk from size 30 to fit into the frame
+            </para>
+        </keepInFrame>
+        <nextFrame/>
+        <keepInFrame maxWidth="72"  maxHeight="36">
+            <para fontSize="30">
+                This text should be shrunk from size 30 to fit into the frame
+            </para>
+        </keepInFrame>
+        <nextFrame/>
+        <keepInFrame onOverflow="error">
+            <para fontSize="20">
+                onOverflow=error
+            </para>
+        </keepInFrame>
+        <nextFrame/>
+        <keepInFrame onOverflow="truncate">
+            <para fontSize="30">
+                Truncate this text!!
+            </para>
+        </keepInFrame>
+        <nextFrame/>
+        <keepInFrame onOverflow="overflow">
+            <para fontSize="30">
+                This text will remain size 30 and overflow out of the frame!
+            </para>
+        </keepInFrame>
+    </story>
+</document>

--- a/tests/test_keepinframe_tag.py
+++ b/tests/test_keepinframe_tag.py
@@ -1,0 +1,33 @@
+import unittest
+
+import trml2pdf
+from reportlab.platypus.doctemplate import LayoutError
+
+
+class TestKeepInFrame(unittest.TestCase):
+    def test_error_mode(self):
+        """ Tests that a LayoutError is raised if the onOverflow
+        attribute for a keepInFrame tag is set to "error" and the
+        content does not fit in the frame.
+        """
+        rml = """
+        <!DOCTYPE document SYSTEM "rml.dtd">
+        <document>
+            <template pageSize="(8.5in, 11in)" showBoundary="1">
+                <pageTemplate id="main">
+                    <frame id="i" x1="1in" y1="9in" width="2in" height="1in"/>
+                </pageTemplate>
+            </template>
+            <stylesheet>
+            </stylesheet>
+            <story>
+                <keepInFrame onOverflow="error">
+                    <para fontSize="30">
+                        This should raise a LayoutError!!!!!!!!!!!!
+                    </para>
+                </keepInFrame>
+            </story>
+        </document>
+        """
+        with self.assertRaises(LayoutError):
+            trml2pdf.parseString(rml)

--- a/trml2pdf/trml2pdf.py
+++ b/trml2pdf/trml2pdf.py
@@ -654,6 +654,23 @@ class _rml_flowable(object):
             return platypus.CondPageBreak(1000)  # TODO: change the 1000 !
         elif node.localName == 'ul':
             return self._list(node)
+        elif node.localName == 'keepInFrame':
+            substory = self.render(node)
+            kwargs = {
+                "maxWidth": 0,
+                "maxHeight": 0,
+                "content": substory,
+            }
+            mode = node.getAttribute("onOverflow")
+            if mode:
+                kwargs["mode"] = mode
+            name = node.getAttribute("id")
+            if name:
+                kwargs["name"] = name
+            kwargs.update(
+                utils.attr_get(node, ['maxWidth','maxHeight', 'mergeSpace'],
+                               {'maxWidth': 'int','maxHeight': 'int'}))
+            return platypus.KeepInFrame(**kwargs)
         else:
             sys.stderr.write(
                 'Warning: flowable not yet implemented: %s !\n' % (node.localName,))


### PR DESCRIPTION
I've added an example of the RML and the resulting PDF, and a unit test for when the `onOverflow` attribute is set to "error" and the content does not fit in the frame.

Note:
The RML docs from reportlab specify that the keepInFrame tag can take an optional `frame` attribute to specify a frame for the tag. This attribute is however not supported by the keepInFrame implementation in reportlab (in reportlab.platypus.flowables.KeepInFrame), and will not do anything if used.
