### PR TITLE
feature: add support for image mask

### DIFF
--- a/trml2pdf/trml2pdf.py
+++ b/trml2pdf/trml2pdf.py
@@ -388,6 +388,8 @@ class _rml_canvas(object):
 
         if node.hasAttribute("preserveAspectRatio"):
             args["preserveAspectRatio"] = True
+        if node.hasAttribute('mask'):
+            args['mask'] = node.getAttribute('mask')
         if ('width' in args) and ('height' not in args):
             args['height'] = sy * args['width'] / sx
         elif ('height' in args) and ('width' not in args):


### PR DESCRIPTION
When you need to embed an image (e.g. a watermark) with text, you can use mask to apply transparency images.

```XML
<illustration width="200" height="150">
    <image
            file="{{rml_root}}/watermark.png"
            x="350" y="100" width="150" height="150"
            mask="auto" />
</illustration>
```