### PR TITLE
add support for registerFontFamily tag

### DIFF
--- a/trml2pdf/trml2pdf.py
+++ b/trml2pdf/trml2pdf.py
@@ -371,7 +371,7 @@ class _rml_canvas(object):
             dashes = node.getAttribute('dash').split(',')
             for x in range(len(dashes)):
                 dashes[x] = utils.unit_get(dashes[x])
-            self.canvas.setDash(node.getAttribute('dash').split(','))
+            self.canvas.setDash(dashes)
 
     def _image(self, node):
         from six.moves import urllib

--- a/trml2pdf/trml2pdf.py
+++ b/trml2pdf/trml2pdf.py
@@ -222,13 +222,18 @@ class _rml_doc(object):
 
         for node in els:
             for font in node.getElementsByTagName('registerFont'):
-                name = font.getAttribute('fontName').encode('ascii')
-                fname = font.getAttribute('fontFile').encode('ascii')
+                name = font.getAttribute('fontName')
+                fname = font.getAttribute('fontFile')
                 pdfmetrics.registerFont(TTFont(name, fname))
-                addMapping(name, 0, 0, name)  # normal
-                addMapping(name, 0, 1, name)  # italic
-                addMapping(name, 1, 0, name)  # bold
-                addMapping(name, 1, 1, name)  # italic and bold
+            for font_family in node.getElementsByTagName('registerFontFamily'):
+                normal = font_family.getAttribute('normal')
+                bold = font_family.getAttribute('bold')
+                italic = font_family.getAttribute('italic')
+                bold_italic = font_family.getAttribute('boldItalic')
+                addMapping(normal, 0, 0, normal)  # normal
+                addMapping(normal, 1, 0, bold)  # bold
+                addMapping(normal, 0, 1, italic)  # italic
+                addMapping(normal, 1, 1, bold_italic)  # italic and bold
 
     def render(self, out):
         el = self.dom.documentElement.getElementsByTagName('docinit')


### PR DESCRIPTION
Hi,
current implementation of `<registerFont>` in `trml2pdf` sets the font beign registered to be used for all font weights and styles, which makes tags `<b>` and `<i>` not work.
This pull request implements `<registerFontFamily>`, which allows you to register the font family according to the RML specification.

I wanted to add an example, but I wonder if I can add some example font to the repository.
Real world example is here: https://github.com/leprikon-cz/leprikon/blob/master/leprikon/templates/leprikon/registration_pdf/subject.rml#L11