### PR TITLE
Fix unit tests for python 3.8 and 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
           # - macos-latest  # macOS-10.14
           # - windows-2016
           # - windows-latest  # windows-2019
-        python-version: [2.7, 3.7, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,12 @@
 import os
 from setuptools import setup, find_packages
 
-import trml2pdf
 
 README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
 
 setup(
     name='trml2pdf',
-    version=trml2pdf.__version__,
+    version='0.6',
     description='Tiny RML2PDF is open source implementation of RML (Report Markup Language) from ReportLab',
     keywords='pdf reportlab',
     platforms=["any"],

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@
 
 [tox]
 envlist = py37, py38, py39
+skip_missing_interpreters = true
 
 [gh-actions]
 python =
@@ -13,7 +14,8 @@ python =
     3.9: py39
 
 [testenv]
-commands = python3 setup.py test
+commands = pytest 
 deps = 
+    pytest
 	reportlab>=3.2.0
 	six>=1.9.0

--- a/trml2pdf/__init__.py
+++ b/trml2pdf/__init__.py
@@ -15,7 +15,6 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-__version__ = "0.6"
 
 from . import doc
 


### PR DESCRIPTION
in python 3.8 and 3.9 it loads setup.py and `trml2pdf` before installing dependencies and fails to do so due to missing `reportlab`

- hardcore version in the setup.py instead of importing it from `trml2pdf.__init__.py`
- use tox recommended command to run unit tests, `setup.py test` is deprecated