### PR TITLE
Support quiet/lquiet/rquiet on Code 128

### DIFF
--- a/trml2pdf/canv.py
+++ b/trml2pdf/canv.py
@@ -192,7 +192,7 @@ class RmlCanvas(object):
             if node.hasAttribute(tag):
                 drawargs[tag] = utils.unit_get(node.getAttribute(tag))
         if code_type == 'Code128':
-            for tag in ('barWidth', 'barHeight'):
+            for tag in ('barWidth', 'barHeight', 'quiet', 'lquiet', 'rquiet'):
                 if node.hasAttribute(tag):
                     createargs[tag] = utils.unit_get(node.getAttribute(tag))
             barcode = code128.Code128(self._textual(node), **createargs)


### PR DESCRIPTION
Add support for the quiet attribute for the Code 128 barcode, along with the left/right variants.